### PR TITLE
docs: add client docs links, change links from bonitoo-io to InfluxData

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -8,7 +8,7 @@ about: Opening a feature request kicks off a discussion
 Thank you for suggesting an idea to improve this client. 
 
 * Please add a :+1: or comment on a similar existing feature request instead of opening a new one.
-https://github.com/bonitoo-io/influxdb-client-dart/issues?q=is%3Aissue+is%3Aopen+is%3Aclosed+sort%3Aupdated-desc
+https://github.com/influxdata/influxdb-client-dart/issues?q=is%3Aissue+is%3Aopen+is%3Aclosed+sort%3Aupdated-desc
 
 -->
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,15 +1,15 @@
 ## 1.0.0 [unreleased]
 
 ## 0.1.0-dev.5 [2021-05-07]
-1. [#6](https://github.com/bonitoo-io/influxdb-client-dart/pull/6): Exponential random backoff retry strategy
+1. [#6](https://github.com/influxdata/influxdb-client-dart/pull/6): Exponential random backoff retry strategy
 
 ## 0.1.0-dev.4 [2021-04-02]
 
 ### API
-1. [#5](https://github.com/bonitoo-io/influxdb-client-dart/pull/5): Updated swagger to the latest version
+1. [#5](https://github.com/influxdata/influxdb-client-dart/pull/5): Updated swagger to the latest version
  
 ### CI
-1. [#4](https://github.com/bonitoo-io/influxdb-client-dart/pull/4): Updated stable image to `influxdb:latest` and nightly to `quay.io/influxdb/influxdb:nightly`
+1. [#4](https://github.com/influxdata/influxdb-client-dart/pull/4): Updated stable image to `influxdb:latest` and nightly to `quay.io/influxdb/influxdb:nightly`
 
 ## 0.1.0-dev.3 [2021-03-05]
 

--- a/README.md
+++ b/README.md
@@ -29,6 +29,15 @@ Please submit issues and pull requests, help out, or just give encouragement.
 - [Contributing](#contributing)
 - [License](#license)
 
+## Documentation
+
+This section contains links to the client library documentation.
+
+* [Product documentation](https://docs.influxdata.com/influxdb/v2.0/api-guide/client-libraries/), [Getting Started](#installation)
+* [Examples](example)
+* [API Reference](https://pub.dev/documentation/influxdb_client/latest/influxdb_client_api/InfluxDBClient-class.html)
+* [Changelog](CHANGELOG.md)
+
 ## Features
 
 InfluxDB 2.0 client supports:

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # influxdb-client-dart
 
-[![CircleCI](https://circleci.com/gh/bonitoo-io/influxdb-client-dart.svg?style=svg)](https://circleci.com/gh/bonitoo-io/influxdb-client-dart)
-[![Platforms](https://img.shields.io/badge/platform-dart|flutter-blue.svg)](https://github.com/bonitoo-io/influxdb-client-dart/)
+[![CircleCI](https://circleci.com/gh/influxdata/influxdb-client-dart.svg?style=svg)](https://circleci.com/gh/influxdata/influxdb-client-dart)
+[![Platforms](https://img.shields.io/badge/platform-dart|flutter-blue.svg)](https://github.com/influxdata/influxdb-client-dart/)
 ![Pub Version](https://img.shields.io/pub/v/influxdb_client)
-[![License](https://img.shields.io/github/license/bonitoo-io/influxdb-client-dart.svg)](https://github.com/bonitoo-io/influxdb-client-dart/blob/master/LICENSE)
-[![GitHub issues](https://img.shields.io/github/issues-raw/bonitoo-io/influxdb-client-dart.svg)](https://github.com/bonitoo-io/influxdb-client-dart/issues)
-[![GitHub pull requests](https://img.shields.io/github/issues-pr-raw/bonitoo-io/influxdb-client-dart.svg)](https://github.com/bonitoo-io/influxdb-client-dart/pulls)
+[![License](https://img.shields.io/github/license/influxdata/influxdb-client-dart.svg)](https://github.com/influxdata/influxdb-client-dart/blob/master/LICENSE)
+[![GitHub issues](https://img.shields.io/github/issues-raw/influxdata/influxdb-client-dart.svg)](https://github.com/influxdata/influxdb-client-dart/issues)
+[![GitHub pull requests](https://img.shields.io/github/issues-pr-raw/influxdata/influxdb-client-dart.svg)](https://github.com/influxdata/influxdb-client-dart/pulls)
 [![Slack Status](https://img.shields.io/badge/slack-join_chat-white.svg?logo=slack&style=social)](https://www.influxdata.com/slack)
 
 #### !!! Disclaimer: This library is a work in progress and should not be considered production ready yet. !!!

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: influxdb_client
 version: 0.1.0-dev.4
 description: A InfluxDB 2.0 API Client Library
-homepage: https://github.com/bonitoo-io/influxdb-client-dart
+homepage: https://github.com/influxdata/influxdb-client-dart
 
 environment:
   sdk: '>=2.3.0 <3.0.0'


### PR DESCRIPTION
1. Added unified documentation section.
2. Changed links from bonitoo-io to InfluxData.