### PR TITLE
fix: link to CLA

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -11,4 +11,4 @@ _Briefly describe your proposed changes:_
 - [ ] A test has been added if appropriate
 - [ ] `pub run test` completes successfully
 - [ ] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
-- [ ] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
+- [ ] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)


### PR DESCRIPTION
## Proposed Changes

Fixed link to CLA.

## Checklist

- [ ] Rebased/mergeable
- [ ] `pub run test` completes successfully
- [ ] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [ ] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)