### PR TITLE
fix: authorization for v1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,7 +58,7 @@ commands:
       - run:
           name: Native compile
           shell: << parameters.shell >>
-          command: dart2native test/influxdb_client_test.dart -o unit-tests.exe
+          command: dart compile exe test/influxdb_client_test.dart -o unit-tests.exe
 #      - store_artifacts:
 #          path: circleci_dart_demo.exe
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## 2.1.0 [unreleased]
 
+### Bug Fixes
+1. [#26](https://github.com/influxdata/influxdb-client-dart/pull/26): Authorization for InfluxDB 1.x
+
 ## 2.0.0 [2021-11-26]
 
 ### Features

--- a/lib/client/influxdb_client.dart
+++ b/lib/client/influxdb_client.dart
@@ -199,7 +199,7 @@ class InfluxDBClient {
 
     // 1.8 compatibility token
     if (username != null && password != null && token == null) {
-      token = '$username:$password';
+      this.token = '$username:$password';
     }
     defaultHeaders['User-Agent'] = '${CLIENT_NAME}/$CLIENT_VERSION';
   }

--- a/test/influxdb_client_test.dart
+++ b/test/influxdb_client_test.dart
@@ -1,4 +1,6 @@
 import 'package:influxdb_client/api.dart';
+import 'package:http/http.dart';
+import 'package:http/testing.dart';
 import 'package:test/test.dart';
 
 import 'commons_test.dart';
@@ -115,5 +117,23 @@ void main() async {
     expect(future, completion(null));
     future = client.getPingApi().headPing();
     expect(future, completion(null));
+  });
+
+  test('v1 authentication', () async {
+    client = InfluxDBClient(
+        url: 'http://localhost:8086',
+        org: 'my-org',
+        username: 'my-username',
+        password: 'my-password');
+
+    var mockClient = MockClient((request) async {
+      expect(request.headers['Authorization'], 'Token my-username:my-password');
+      return Response('', 200);
+    });
+    client.client = mockClient;
+
+    await client.getPingApi().getPing();
+
+    client.close();
   });
 }


### PR DESCRIPTION
Closes #25 

## Proposed Changes

Fix authorisation for `v1` instances.

## Checklist

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `pub run test` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)