### PR TITLE
chore(ci): use recommended ubuntu image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -216,7 +216,7 @@ jobs:
 
   build-linux:
     machine:
-      image: ubuntu-2004:202010-01
+      image: ubuntu-2004:202201-02
     steps:
       - run:
           name: Install Dart SDK


### PR DESCRIPTION
## Proposed Changes

Use the recommended Ubundu image. Related to [Ubuntu 14.04 machine image deprecation & EOL](https://circleci.com/docs/2.0/images/linux-vm/14.04-to-20.04-migration/).

## Checklist

- [ ] Rebased/mergeable
- [ ] `pub run test` completes successfully
- [ ] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [ ] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)