### PR TITLE
chore: rename InvocableScripts to InvokableScripts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## 2.4.0 [unreleased]
 
+### Breaking Changes
+1. [#42](https://github.com/influxdata/influxdb-client-dart/pull/42): Rename `InvocableScripts` to `InvokableScripts`
+
 ## 2.3.0 [2022-04-19]
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 2.3.0 [2022-04-19]
 
 ### Features
-1. [#41](https://github.com/influxdata/influxdb-client-dart/pull/41): Add `InvocableScriptsApi` to create, update, list, delete and invoke scripts by seamless way
+1. [#41](https://github.com/influxdata/influxdb-client-dart/pull/41): Add `InvokableScriptsApi` to create, update, list, delete and invoke scripts by seamless way
 
 ### CI
 1. [#38](https://github.com/influxdata/influxdb-client-dart/pull/38): Report code coverage to Codecov

--- a/example/README.md
+++ b/example/README.md
@@ -15,4 +15,4 @@
 ## Others
 - [delete_data_example.dart](delete_data_example.dart) - How to delete data from InfluxDB by client
 - [main.dart](main.dart) - How to write, query and delete data from InfluxDB
-- [invocable_scripts.dart](invocable_scripts.dart) - How to use Invocable scripts Cloud API to create custom endpoints that query data
+- [invokable_scripts.dart](invokable_scripts.dart) - How to use Invokable scripts Cloud API to create custom endpoints that query data

--- a/example/invokable_scripts.dart
+++ b/example/invokable_scripts.dart
@@ -1,7 +1,7 @@
 import 'package:influxdb_client/api.dart';
 
 /*
- *  warning: Invocable Scripts are supported only in InfluxDB Cloud, currently there is no support in InfluxDB OSS.
+ *  warning: Invokable Scripts are supported only in InfluxDB Cloud, currently there is no support in InfluxDB OSS.
  */
 
 void main() async {
@@ -23,10 +23,10 @@ void main() async {
       .addField('temperature', 24.3);
   await client.getWriteService().write([point1, point2]);
 
-  var scriptsService = client.getInvocableScriptsService();
+  var scriptsService = client.getInvokableScriptsService();
 
   //
-  // Create Invocable Script
+  // Create Invokable Script
   //
   print('\n------- Create -------\n');
   var scriptQuery =
@@ -41,7 +41,7 @@ void main() async {
   print(createdScript);
 
   //
-  // Update Invocable Script
+  // Update Invokable Script
   //
   print('\n------- Update -------\n');
   var updateRequest =

--- a/lib/api.dart
+++ b/lib/api.dart
@@ -147,8 +147,8 @@ part 'model/is_onboarding.dart';
 part 'model/onboarding_request.dart';
 part 'model/onboarding_response.dart';
 
-//invocable_scripts
-part 'api/invocable_scripts_api.dart';
+//invokable_scripts
+part 'api/invokable_scripts_api.dart';
 part 'model/script.dart';
 part 'model/scripts.dart';
 part 'model/script_create_request.dart';
@@ -164,7 +164,7 @@ part 'client/point.dart';
 part 'client/delete_service.dart';
 part 'client/write_service.dart';
 part 'client/query_service.dart';
-part 'client/invocable_scripts_service.dart';
+part 'client/invokable_scripts_service.dart';
 part 'client/flux_transformer.dart';
 part 'client/flux_table.dart';
 part 'client/retry.dart';

--- a/lib/api/invokable_scripts_api.dart
+++ b/lib/api/invokable_scripts_api.dart
@@ -8,8 +8,8 @@
 
 part of influxdb_client_api;
 
-class InvocableScriptsApi {
-  InvocableScriptsApi(ApiClient apiClient) : apiClient = apiClient;
+class InvokableScriptsApi {
+  InvokableScriptsApi(ApiClient apiClient) : apiClient = apiClient;
 
   final ApiClient apiClient;
 
@@ -141,7 +141,7 @@ class InvocableScriptsApi {
 
   /// Retrieve a script
   ///
-  /// Uses script ID to retrieve details of an invocable script.
+  /// Uses script ID to retrieve details of an invokable script.
   ///
   /// Note: This method returns the HTTP [Response].
   ///
@@ -178,7 +178,7 @@ class InvocableScriptsApi {
 
   /// Retrieve a script
   ///
-  /// Uses script ID to retrieve details of an invocable script.
+  /// Uses script ID to retrieve details of an invokable script.
   ///
   /// Parameters:
   ///
@@ -203,7 +203,7 @@ class InvocableScriptsApi {
 
   /// Update a script
   ///
-  /// Updates properties (`name`, `description`, and `script`) of an invocable script.
+  /// Updates properties (`name`, `description`, and `script`) of an invokable script.
   ///
   /// Note: This method returns the HTTP [Response].
   ///
@@ -244,7 +244,7 @@ class InvocableScriptsApi {
 
   /// Update a script
   ///
-  /// Updates properties (`name`, `description`, and `script`) of an invocable script.
+  /// Updates properties (`name`, `description`, and `script`) of an invokable script.
   ///
   /// Parameters:
   ///

--- a/lib/client/flux_transformer.dart
+++ b/lib/client/flux_transformer.dart
@@ -30,7 +30,7 @@ enum FluxResponseMode {
   /// full information about types, default values and groups
   full,
 
-  /// useful for Invocable scripts
+  /// useful for Invokable scripts
   only_names
 }
 

--- a/lib/client/influxdb_client.dart
+++ b/lib/client/influxdb_client.dart
@@ -314,9 +314,9 @@ class InfluxDBClient {
     return PingApi(getApiClient(basePath: ''));
   }
 
-  /// Create an InvocableScripts API instance.
-  InvocableScriptsService getInvocableScriptsService() {
-    return InvocableScriptsService(this);
+  /// Create an InvokableScripts API instance.
+  InvokableScriptsService getInvokableScriptsService() {
+    return InvokableScriptsService(this);
   }
 }
 

--- a/lib/client/invokable_scripts_service.dart
+++ b/lib/client/invokable_scripts_service.dart
@@ -5,14 +5,14 @@ part of influxdb_client_api;
 ///
 /// API invokable scripts let you assign scripts to API endpoints and then
 /// execute them as standard REST operations in InfluxDB Cloud.
-class InvocableScriptsService extends DefaultService {
-  late InvocableScriptsApi service;
+class InvokableScriptsService extends DefaultService {
+  late InvokableScriptsApi service;
 
   ///
-  /// Creates [InvocableScriptsService] with optional custom [writeOptions]
+  /// Creates [InvokableScriptsService] with optional custom [writeOptions]
   ///
-  InvocableScriptsService(InfluxDBClient client) : super(client) {
-    service = InvocableScriptsApi(client.getApiClient());
+  InvokableScriptsService(InfluxDBClient client) : super(client) {
+    service = InvokableScriptsApi(client.getApiClient());
   }
 
   /// Create a script.

--- a/scripts/generate-sources.sh
+++ b/scripts/generate-sources.sh
@@ -53,7 +53,7 @@ cp -r ${SRC}/api/dbrps_api.dart $OUT/api
 cp -r ${SRC}/api/setup_api.dart $OUT/api
 cp -r ${SRC}/api/write_api.dart $OUT/api
 cp -r ${SRC}/api/ping_api.dart $OUT/api
-cp -r ${SRC}/api/invocable_scripts_api.dart $OUT/api
+cp -r ${SRC}/api/invokable_scripts_api.dart $OUT/api
 
 ### needs manual modification
 #cp -r ${SRC}/api/query_api.dart $OUT/api

--- a/test/influxdb_client_test.dart
+++ b/test/influxdb_client_test.dart
@@ -151,8 +151,8 @@ void main() async {
     expect(client, isNot(null));
   });
 
-  test('create InvocableScriptsService', () async {
-    var invocableScriptsService = client.getInvocableScriptsService();
-    expect(invocableScriptsService, isNot(null));
+  test('create InvokableScriptsService', () async {
+    var invokableScriptsService = client.getInvokableScriptsService();
+    expect(invokableScriptsService, isNot(null));
   });
 }


### PR DESCRIPTION
Related to https://github.com/influxdata/openapi/pull/317

## Proposed Changes

Renamed `InvocableScripts` to `InvokableScripts`.

## Checklist

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] `pub run test` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)