### PR TITLE
fix(line_protocol): serialisation double-quotes in `string` fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## 2.4.0 [unreleased]
 
+### Bug Fixes
+1. [#46](https://github.com/influxdata/influxdb-client-dart/pull/46): Serialisation double-quotes in DataPoint `string` fields
+
 ### Breaking Changes
 1. [#42](https://github.com/influxdata/influxdb-client-dart/pull/42): Rename `InvocableScripts` to `InvokableScripts`
 

--- a/lib/client/point.dart
+++ b/lib/client/point.dart
@@ -148,9 +148,8 @@ class Point {
         case '\"':
           sb.write('\\');
           break;
-        default:
-          sb.write(value[i]);
       }
+      sb.write(value[i]);
     }
   }
 

--- a/test/influxdb_client_test.dart
+++ b/test/influxdb_client_test.dart
@@ -159,7 +159,7 @@ void main() async {
   });
 
   test('store Dynamic structure', () async {
-
+    var client = createClient();
     var configID = DateTime.now().millisecondsSinceEpoch.toString();
 
     var temperature = CustomConfig('Temperature', 'Temperature', '°C');
@@ -169,9 +169,7 @@ void main() async {
     var point = Point('config')
         .addTag('id', configID)
         .addField('value', jsonEncode(toWrite));
-    await writeApi
-        .write(point)
-        .whenComplete(() => {});
+    await client.getWriteService().write(point).whenComplete(() => {});
 
     var query = '''from(bucket: "my-bucket") 
         |> range(start: 0)
@@ -186,6 +184,8 @@ void main() async {
         .map((config) => CustomConfig.fromJson(config))
         .toList();
     expect(toWrite, fromQuery);
+
+    client.close();
   });
 }
 
@@ -202,17 +202,19 @@ class CustomConfig {
         unit = json['unit'];
 
   Map<String, dynamic> toJson() => {
-    'measurement': measurement,
-    'label': label,
-    'unit': unit,
-  };
+        'measurement': measurement,
+        'label': label,
+        'unit': unit,
+      };
 
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
-          other is CustomConfig && runtimeType == other.runtimeType &&
-              measurement == other.measurement && label == other.label &&
-              unit == other.unit;
+      other is CustomConfig &&
+          runtimeType == other.runtimeType &&
+          measurement == other.measurement &&
+          label == other.label &&
+          unit == other.unit;
 
   @override
   int get hashCode => measurement.hashCode ^ label.hashCode ^ unit.hashCode;

--- a/test/influxdb_client_test.dart
+++ b/test/influxdb_client_test.dart
@@ -1,3 +1,5 @@
+import 'dart:convert';
+
 import 'package:influxdb_client/api.dart';
 import 'package:http/http.dart';
 import 'package:http/testing.dart';
@@ -155,4 +157,63 @@ void main() async {
     var invokableScriptsService = client.getInvokableScriptsService();
     expect(invokableScriptsService, isNot(null));
   });
+
+  test('store Dynamic structure', () async {
+
+    var configID = DateTime.now().millisecondsSinceEpoch.toString();
+
+    var temperature = CustomConfig('Temperature', 'Temperature', '°C');
+    var pressure = CustomConfig('Pressure', 'Pressure', 'Pa');
+
+    var toWrite = [temperature, pressure];
+    var point = Point('config')
+        .addTag('id', configID)
+        .addField('value', jsonEncode(toWrite));
+    await writeApi
+        .write(point)
+        .whenComplete(() => {});
+
+    var query = '''from(bucket: "my-bucket") 
+        |> range(start: 0)
+        |> filter(fn: (r) => r["_measurement"] == "config")
+        |> filter(fn: (r) => r["id"] == "${configID}")
+        |> filter(fn: (r) => r["_field"] == "value")
+        ''';
+    var resp = await client.getQueryService().query(query);
+    var json = (await resp.toList())[0]['_value'];
+
+    List<CustomConfig> fromQuery = (jsonDecode(json) as List<dynamic>)
+        .map((config) => CustomConfig.fromJson(config))
+        .toList();
+    expect(toWrite, fromQuery);
+  });
+}
+
+class CustomConfig {
+  final String measurement;
+  final String label;
+  final String unit;
+
+  CustomConfig(this.measurement, this.label, this.unit);
+
+  CustomConfig.fromJson(Map<String, dynamic> json)
+      : measurement = json['measurement'],
+        label = json['label'],
+        unit = json['unit'];
+
+  Map<String, dynamic> toJson() => {
+    'measurement': measurement,
+    'label': label,
+    'unit': unit,
+  };
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+          other is CustomConfig && runtimeType == other.runtimeType &&
+              measurement == other.measurement && label == other.label &&
+              unit == other.unit;
+
+  @override
+  int get hashCode => measurement.hashCode ^ label.hashCode ^ unit.hashCode;
 }

--- a/test/point_test.dart
+++ b/test/point_test.dart
@@ -101,5 +101,21 @@ void main() {
       expect(point.toLineProtocol(WritePrecision.s),
           'h2o,location=europe level=2i 1592821564');
     });
+
+    test('fieldEscape', () {
+      var point = Point.measurement('h2o')
+          .addTag('location', 'europe')
+          .addField('level', 'string esc\\ape value');
+
+      expect(point.toLineProtocol(WritePrecision.ns),
+          'h2o,location=europe level=\"string esc\\\\ape value\"');
+
+      point = Point.measurement('h2o')
+          .addTag('location', 'europe')
+          .addField('level', 'string esc\"ape value');
+
+      expect(point.toLineProtocol(WritePrecision.ns),
+          'h2o,location=europe level=\"string esc\\\"ape value\"');
+    });
   });
 }


### PR DESCRIPTION
Closes #45 

## Proposed Changes

Fixed serialisation DataPoint with string field.

## Checklist

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `pub run test` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)