### PR TITLE
chore(ci): add static code analysis to CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -184,6 +184,7 @@ jobs:
       - image: "dart:latest"
     steps:
       - checkout
+      - run: dart pub get
       - run:
           name: Check static analysis formatting
           command: dart analyze --fatal-infos lib

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -84,6 +84,7 @@ workflows:
           dart-image: "dart:2.12"
           influxdb-image: "quay.io/influxdb/influxdb:nightly"
       - check-code-style
+      - check-static-analysis
       - build-windows:
           requires:
             - dart-2.12
@@ -177,6 +178,15 @@ jobs:
       - run:
           name: Check correct formatting
           command: dart format --set-exit-if-changed .
+
+  check-static-analysis:
+    docker:
+      - image: "dart:latest"
+    steps:
+      - checkout
+      - run:
+          name: Check static analysis formatting
+          command: dart analyze --fatal-infos lib
 
   build-windows:
     executor: win/default

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## 2.5.0 [unreleased]
 
+### CI
+1. [#48](https://github.com/influxdata/influxdb-client-dart/pull/48): Add dart analysis to pipeline
+
 ## 2.4.0 [2022-05-20]
 
 ### Bug Fixes

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,4 +1,4 @@
-include: package:pedantic/analysis_options.1.9.0.yaml
+include: package:lints/recommended.yaml
 
 analyzer:
   exclude: [build/**, scripts/**]

--- a/lib/api/authorizations_api.dart
+++ b/lib/api/authorizations_api.dart
@@ -9,7 +9,7 @@
 part of influxdb_client_api;
 
 class AuthorizationsApi {
-  AuthorizationsApi(ApiClient apiClient) : apiClient = apiClient;
+  AuthorizationsApi(this.apiClient);
 
   final ApiClient apiClient;
 

--- a/lib/api/buckets_api.dart
+++ b/lib/api/buckets_api.dart
@@ -9,7 +9,7 @@
 part of influxdb_client_api;
 
 class BucketsApi {
-  BucketsApi(ApiClient apiClient) : apiClient = apiClient;
+  BucketsApi(this.apiClient);
 
   final ApiClient apiClient;
 

--- a/lib/api/dbrps_api.dart
+++ b/lib/api/dbrps_api.dart
@@ -9,7 +9,7 @@
 part of influxdb_client_api;
 
 class DBRPsApi {
-  DBRPsApi(ApiClient apiClient) : apiClient = apiClient;
+  DBRPsApi(this.apiClient);
 
   final ApiClient apiClient;
 

--- a/lib/api/delete_api.dart
+++ b/lib/api/delete_api.dart
@@ -9,7 +9,7 @@
 part of influxdb_client_api;
 
 class DeleteApi {
-  DeleteApi(ApiClient apiClient) : apiClient = apiClient;
+  DeleteApi(this.apiClient);
 
   final ApiClient apiClient;
 

--- a/lib/api/health_api.dart
+++ b/lib/api/health_api.dart
@@ -9,7 +9,7 @@
 part of influxdb_client_api;
 
 class HealthApi {
-  HealthApi(ApiClient apiClient) : apiClient = apiClient;
+  HealthApi(this.apiClient);
 
   final ApiClient apiClient;
 

--- a/lib/api/invokable_scripts_api.dart
+++ b/lib/api/invokable_scripts_api.dart
@@ -9,7 +9,7 @@
 part of influxdb_client_api;
 
 class InvokableScriptsApi {
-  InvokableScriptsApi(ApiClient apiClient) : apiClient = apiClient;
+  InvokableScriptsApi(this.apiClient);
 
   final ApiClient apiClient;
 

--- a/lib/api/labels_api.dart
+++ b/lib/api/labels_api.dart
@@ -9,7 +9,7 @@
 part of influxdb_client_api;
 
 class LabelsApi {
-  LabelsApi(ApiClient apiClient) : apiClient = apiClient;
+  LabelsApi(this.apiClient);
 
   final ApiClient apiClient;
 

--- a/lib/api/organizations_api.dart
+++ b/lib/api/organizations_api.dart
@@ -9,7 +9,7 @@
 part of influxdb_client_api;
 
 class OrganizationsApi {
-  OrganizationsApi(ApiClient apiClient) : apiClient = apiClient;
+  OrganizationsApi(this.apiClient);
 
   final ApiClient apiClient;
 

--- a/lib/api/ping_api.dart
+++ b/lib/api/ping_api.dart
@@ -9,7 +9,7 @@
 part of influxdb_client_api;
 
 class PingApi {
-  PingApi(ApiClient apiClient) : apiClient = apiClient;
+  PingApi(this.apiClient);
 
   final ApiClient apiClient;
 

--- a/lib/api/ready_api.dart
+++ b/lib/api/ready_api.dart
@@ -9,7 +9,7 @@
 part of influxdb_client_api;
 
 class ReadyApi {
-  ReadyApi(ApiClient apiClient) : apiClient = apiClient;
+  ReadyApi(this.apiClient);
 
   final ApiClient apiClient;
 

--- a/lib/api/secrets_api.dart
+++ b/lib/api/secrets_api.dart
@@ -9,7 +9,7 @@
 part of influxdb_client_api;
 
 class SecretsApi {
-  SecretsApi(ApiClient apiClient) : apiClient = apiClient;
+  SecretsApi(this.apiClient);
 
   final ApiClient apiClient;
 

--- a/lib/api/setup_api.dart
+++ b/lib/api/setup_api.dart
@@ -9,7 +9,7 @@
 part of influxdb_client_api;
 
 class SetupApi {
-  SetupApi(ApiClient apiClient) : apiClient = apiClient;
+  SetupApi(this.apiClient);
 
   final ApiClient apiClient;
 

--- a/lib/api/tasks_api.dart
+++ b/lib/api/tasks_api.dart
@@ -9,7 +9,7 @@
 part of influxdb_client_api;
 
 class TasksApi {
-  TasksApi(ApiClient apiClient) : apiClient = apiClient;
+  TasksApi(this.apiClient);
 
   final ApiClient apiClient;
 

--- a/lib/api/users_api.dart
+++ b/lib/api/users_api.dart
@@ -9,7 +9,7 @@
 part of influxdb_client_api;
 
 class UsersApi {
-  UsersApi(ApiClient apiClient) : apiClient = apiClient;
+  UsersApi(this.apiClient);
 
   final ApiClient apiClient;
 

--- a/lib/api/variables_api.dart
+++ b/lib/api/variables_api.dart
@@ -9,7 +9,7 @@
 part of influxdb_client_api;
 
 class VariablesApi {
-  VariablesApi(ApiClient apiClient) : apiClient = apiClient;
+  VariablesApi(this.apiClient);
 
   final ApiClient apiClient;
 

--- a/lib/api/write_api.dart
+++ b/lib/api/write_api.dart
@@ -9,7 +9,7 @@
 part of influxdb_client_api;
 
 class WriteApi {
-  WriteApi(ApiClient apiClient) : apiClient = apiClient;
+  WriteApi(this.apiClient);
 
   final ApiClient apiClient;
 

--- a/lib/api_client.dart
+++ b/lib/api_client.dart
@@ -21,19 +21,8 @@ class ApiClient {
 
   final String basePath;
 
-  var _client = Client();
-
-  /// Returns the current HTTP [Client] instance to use in this class.
-  ///
-  /// The return value is guaranteed to never be null.
-  Client get client => _client;
-
-  /// Requests to use a new HTTP [Client] in this class.
-  ///
-  /// If the [newClient] is null, an [ArgumentError] is thrown.
-  set client(Client newClient) {
-    _client = newClient;
-  }
+  /// The HTTP [Client] instance to use in this class.
+  var client = Client();
 
   final _defaultHeaderMap = <String, String>{};
   final _authentications = <String, Authentication>{};
@@ -99,7 +88,7 @@ class ApiClient {
               onError: (Object error, StackTrace trace) => request.sink.close(),
               cancelOnError: true,
             );
-        final response = await _client.send(request);
+        final response = await client.send(request);
         return Response.fromStream(response);
       }
 
@@ -109,7 +98,7 @@ class ApiClient {
         request.files.addAll(body.files);
         request.headers.addAll(body.headers);
         request.headers.addAll(headerParams);
-        final response = await _client.send(request);
+        final response = await client.send(request);
         return Response.fromStream(response);
       }
 
@@ -120,36 +109,36 @@ class ApiClient {
 
       switch (method) {
         case 'POST':
-          return await _client.post(
+          return await client.post(
             uri,
             headers: nullableHeaderParams,
             body: msgBody,
           );
         case 'PUT':
-          return await _client.put(
+          return await client.put(
             uri,
             headers: nullableHeaderParams,
             body: msgBody,
           );
         case 'DELETE':
-          return await _client.delete(
+          return await client.delete(
             uri,
             headers: nullableHeaderParams,
             body: msgBody,
           );
         case 'PATCH':
-          return await _client.patch(
+          return await client.patch(
             uri,
             headers: nullableHeaderParams,
             body: msgBody,
           );
         case 'HEAD':
-          return await _client.head(
+          return await client.head(
             uri,
             headers: nullableHeaderParams,
           );
         case 'GET':
-          return await _client.get(
+          return await client.get(
             uri,
             headers: nullableHeaderParams,
           );

--- a/lib/client/error.dart
+++ b/lib/client/error.dart
@@ -24,7 +24,7 @@ class InfluxDBException implements Exception {
     } catch (e) {
       message = errorBody;
     }
-    var retryAfter;
+    var retryAfter = -1;
     if (headers[HttpHeaders.retryAfterHeader] != null) {
       try {
         retryAfter = int.parse(headers[HttpHeaders.retryAfterHeader]!);

--- a/lib/client/flux_transformer.dart
+++ b/lib/client/flux_transformer.dart
@@ -1,9 +1,9 @@
 part of influxdb_client_api;
 
-const ANNOTATION_DEFAULT = '#default';
-const ANNOTATION_GROUP = '#group';
-const ANNOTATION_DATATYPE = '#datatype';
-const ANNOTATIONS = [ANNOTATION_DEFAULT, ANNOTATION_GROUP, ANNOTATION_DATATYPE];
+const annotationDefault = '#default';
+const annotationGroup = '#group';
+const annotationDatatype = '#datatype';
+const annotations = [annotationDefault, annotationGroup, annotationDatatype];
 
 /// [FluxQueryException] is thrown when Flux response contains error from server
 class FluxQueryException implements Exception {
@@ -31,7 +31,7 @@ enum FluxResponseMode {
   full,
 
   /// useful for Invokable scripts
-  only_names
+  onlyNames
 }
 
 /// Parses Flux query result and transforms the CSV stream of List<dynamic>
@@ -109,8 +109,8 @@ class FluxTransformer implements StreamTransformer<List, FluxRecord> {
 
     // check csv annotations
     var token = csv[0];
-    if ((ANNOTATIONS.contains(token) && !startNewTable) ||
-        (responseMode == FluxResponseMode.only_names && table == null)) {
+    if ((annotations.contains(token) && !startNewTable) ||
+        (responseMode == FluxResponseMode.onlyNames && table == null)) {
       startNewTable = true;
       table = FluxTableMetaData(tableIndex);
       tableIndex++;
@@ -119,15 +119,15 @@ class FluxTransformer implements StreamTransformer<List, FluxRecord> {
       throw FluxCsvParserException(
           'Unable to parse CSV response. FluxTable definition was not found.');
     }
-    if (ANNOTATION_DATATYPE == token) {
+    if (annotationDatatype == token) {
       _addDataTypes(table!, csv);
-    } else if (ANNOTATION_GROUP == token) {
+    } else if (annotationGroup == token) {
       groups = csv;
-    } else if (ANNOTATION_DEFAULT == token) {
+    } else if (annotationDefault == token) {
       _addDefaultEmptyValues(table!, csv);
     } else {
       if (startNewTable) {
-        if (responseMode == FluxResponseMode.only_names &&
+        if (responseMode == FluxResponseMode.onlyNames &&
             table!.columns.isEmpty) {
           _addDataTypes(table!, csv.map((e) => 'string').toList());
           groups = csv.map((e) => 'false').toList();

--- a/lib/client/flux_transformer.dart
+++ b/lib/client/flux_transformer.dart
@@ -48,7 +48,7 @@ class FluxTransformer implements StreamTransformer<List, FluxRecord> {
   var tableId = -1;
   var startNewTable = false;
   var parsingStateError = false;
-  var groups;
+  var groups = [];
 
   // Original Stream
   late Stream<List> _stream;

--- a/lib/client/influxdb_client.dart
+++ b/lib/client/influxdb_client.dart
@@ -1,7 +1,7 @@
 part of influxdb_client_api;
 
-String CLIENT_VERSION = '2.5.0-dev';
-String CLIENT_NAME = 'influxdb-client-dart';
+String clientVersion = '2.5.0-dev';
+String clientName = 'influxdb-client-dart';
 
 ///
 /// Superclass for all services.
@@ -212,7 +212,7 @@ class InfluxDBClient {
     if (username != null && password != null && token == null) {
       this.token = '$username:$password';
     }
-    defaultHeaders['User-Agent'] = '${CLIENT_NAME}/$CLIENT_VERSION';
+    defaultHeaders['User-Agent'] = '$clientName/$clientVersion';
   }
 
   String? token;

--- a/lib/client/influxdb_client.dart
+++ b/lib/client/influxdb_client.dart
@@ -199,17 +199,14 @@ class InfluxDBClient {
       String? password,
 
       /// verbose logging of http calls
-      bool debug = false,
-      maxRedirects = 5,
-      followRedirects = true}) {
+      this.debug = false,
+      this.maxRedirects = 5,
+      this.followRedirects = true}) {
     this.url = url ?? const String.fromEnvironment('INFLUXDB_URL');
     this.token = token ?? const String.fromEnvironment('INFLUXDB_TOKEN');
     this.bucket = bucket ?? const String.fromEnvironment('INFLUXDB_BUCKET');
     this.org = org ?? const String.fromEnvironment('INFLUXDB_ORG');
     this.client = client ?? LoggingClient(debug, Client());
-    this.debug = debug;
-    this.maxRedirects = maxRedirects;
-    this.followRedirects = followRedirects;
 
     // 1.8 compatibility token
     if (username != null && password != null && token == null) {

--- a/lib/client/influxdb_client.dart
+++ b/lib/client/influxdb_client.dart
@@ -241,7 +241,7 @@ class InfluxDBClient {
       authentication.apiKeyPrefix = 'Token';
       authentication.apiKey = token;
     }
-    api._client = client;
+    api.client = client;
     api._defaultHeaderMap.addAll(defaultHeaders);
     return api;
   }

--- a/lib/client/invokable_scripts_service.dart
+++ b/lib/client/invokable_scripts_service.dart
@@ -67,7 +67,7 @@ class InvokableScriptsService extends DefaultService {
     return _invokeScript(scriptId, params: params).then((value) => utf8.decoder
         .bind(value.stream)
         .transform(CsvToListConverter())
-        .transform(FluxTransformer(responseMode: FluxResponseMode.only_names)));
+        .transform(FluxTransformer(responseMode: FluxResponseMode.onlyNames)));
   }
 
   /// Invoke a script and return result as a row of CSV response.

--- a/lib/client/point.dart
+++ b/lib/client/point.dart
@@ -145,7 +145,7 @@ class Point {
     for (var i = 0; i < value.length; i++) {
       switch (value[i]) {
         case '\\':
-        case '\"':
+        case '"':
           sb.write('\\');
           break;
       }

--- a/lib/client/query_service.dart
+++ b/lib/client/query_service.dart
@@ -8,7 +8,7 @@ class QueryOptions {
 
 final defaultQueryOptions = QueryOptions(gzip: true);
 
-final Dialect DEFAULT_dialect = Dialect(
+final Dialect defaultDialect = Dialect(
     header: true,
     delimiter: ',',
     annotations: [
@@ -75,7 +75,7 @@ class QueryService extends DefaultService {
     var query = fluxQuery is Query ? fluxQuery : Query(query: fluxQuery);
 
     query.params = params ?? query.params;
-    query.dialect = query.dialect ?? DEFAULT_dialect;
+    query.dialect = query.dialect ?? defaultDialect;
 
     var response = await _send('/api/v2/query', {'org': influxDB.org}, query);
     return utf8.decoder

--- a/lib/client/retry.dart
+++ b/lib/client/retry.dart
@@ -49,7 +49,7 @@ class RetryOptions {
     if (attempt <= 0) {
       return Duration.zero;
     } else if (attempt > maxRetries) {
-      throw RetryException('Retry attempt beyond limit (${maxRetries})');
+      throw RetryException('Retry attempt beyond limit ($maxRetries)');
     }
 
     final rand = _rand.nextDouble();
@@ -122,7 +122,7 @@ class RetryOptions {
         // Sleep for suggested delay but respect timeout
         final duration = delay(attempt, retryAfter, deadline);
         logPrint('The retryable error occurred during request. '
-            'Reason: ${e} Attempt: ${attempt} '
+            'Reason: $e Attempt: $attempt '
             'Next retry in: ${duration.inSeconds}s. (${duration.toString()})');
         await Future.delayed(duration);
       }

--- a/lib/client/write_service.dart
+++ b/lib/client/write_service.dart
@@ -182,7 +182,7 @@ class WriteService extends DefaultService {
   void _checkNotNull(String parameter, dynamic value) {
     if (value == null) {
       throw ArgumentError(
-          'The ${parameter} should be defined as argument or default option in client settings');
+          'The $parameter should be defined as argument or default option in client settings');
     }
   }
 

--- a/lib/client/write_service.dart
+++ b/lib/client/write_service.dart
@@ -223,10 +223,7 @@ class _WriteBatch {
   WriteOptions? writeOptions;
   ListQueue<_BatchItem> queue = ListQueue();
 
-  _WriteBatch(WriteOptions? writeOptions, WriteService writeService) {
-    this.writeOptions = writeOptions;
-    this.writeService = writeService;
-  }
+  _WriteBatch(this.writeOptions, this.writeService);
 
   Future<void> push(dynamic payload) async {
     if (payload is Iterable) {

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -288,6 +288,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "5.0.2"
+  lints:
+    dependency: "direct dev"
+    description:
+      name: lints
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.0.1"
   logging:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -21,3 +21,4 @@ dev_dependencies:
   mockito: any
   collection: any
   test: any
+  lints: ^1.0.1

--- a/scripts/templates/dart2/api.mustache
+++ b/scripts/templates/dart2/api.mustache
@@ -3,7 +3,7 @@
 {{#operations}}
 
 class {{{classname}}} {
-  {{{classname}}}(ApiClient apiClient) : apiClient = apiClient;
+  {{{classname}}}(this.apiClient);
 
   final ApiClient apiClient;
   {{#operation}}

--- a/test/flux_transformer_test.dart
+++ b/test/flux_transformer_test.dart
@@ -12,7 +12,7 @@ void main() {
     test('parseWithoutDatatype', () async {
       var records = await Stream<String>.value(withoutMetadata)
           .transform(CsvToListConverter())
-          .transform(FluxTransformer(responseMode: FluxResponseMode.only_names))
+          .transform(FluxTransformer(responseMode: FluxResponseMode.onlyNames))
           .toList();
       print(records);
       expect(records.length, 2);

--- a/test/query_stream_test.dart
+++ b/test/query_stream_test.dart
@@ -21,7 +21,7 @@ void main() {
   |> filter(fn: (r) => r["_measurement"] == "temperature")
   ''';
 
-    var q = Query(query: fluxQuery, dialect: DEFAULT_dialect);
+    var q = Query(query: fluxQuery, dialect: defaultDialect);
 
     var r = Request(
         'POST', Uri.parse('http://localhost:8086/api/v2/query?org=my-org'));
@@ -49,7 +49,7 @@ void main() {
   |> range(start: 0)
   |> filter(fn: (r) => r["_measurement"] == "temperature")
   ''';
-    var q = Query(query: fluxQuery, dialect: DEFAULT_dialect);
+    var q = Query(query: fluxQuery, dialect: defaultDialect);
     var r = Request(
         'POST', Uri.parse('http://localhost:8086/api/v2/query?org=my-org'));
 

--- a/test/write_test.dart
+++ b/test/write_test.dart
@@ -104,4 +104,20 @@ void main() {
 
     await deleteTestBucket(bucket);
   });
+
+  test('writeBatch', () async {
+    var mockClient = MockClient((request) async {
+      var body = request.body.toString();
+      expect(body.contains('mem,tag=a value=1'), true);
+      expect(body.contains('mem,tag=b value=2'), true);
+      return Response('', 204);
+    });
+
+    var clientMock = createClient();
+    clientMock.client = mockClient;
+    var writeService = clientMock.getWriteService();
+
+    writeService.batchWrite(["mem,tag=a value=1", "mem,tag=b value=2"]);
+    await writeService.flush();
+  });
 }


### PR DESCRIPTION
## Proposed Changes

The `pub.dev` uses new static analysis for code quality: https://pub.dev/packages/lints. This PR integrates this analysis into our CI pipeline.

![image](https://user-images.githubusercontent.com/455137/169760057-35fbb604-b163-4ed9-9600-1c94b092e44c.png)


## Checklist

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] `pub run test` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)