### PR TITLE
fix(web): don't set Accept-Encoding for requests without compression

### DIFF
--- a/.github/workflows/semantic.yml
+++ b/.github/workflows/semantic.yml
@@ -5,7 +5,7 @@ on:
   pull_request:
     types: [opened, reopened, synchronize, edited]
     branches:
-      - master
+      - main
 
 jobs:
   semantic:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## 2.5.0 [unreleased]
 
+### Bug Fixes
+1. [#50](https://github.com/influxdata/influxdb-client-dart/pull/50): Don't set `Accept-Encoding` for requests without compression [Web]
+
 ### CI
 1. [#48](https://github.com/influxdata/influxdb-client-dart/pull/48): Add dart analysis to pipeline
 

--- a/lib/client/influxdb_client.dart
+++ b/lib/client/influxdb_client.dart
@@ -46,7 +46,9 @@ abstract class DefaultService {
       bool enableGzip, body) async {
     var uri = _buildUri(influxDB.url!, path, queryParams);
     Map<String, String> headers = {};
-    headers[r'Accept-Encoding'] = enableGzip ? 'gzip' : 'identity';
+    if (enableGzip) {
+      headers[r'Accept-Encoding'] = 'gzip';
+    }
     headers[r'Content-Type'] = 'application/json';
     _updateParamsForAuth(headers);
     return await (_invoke(uri, 'POST',

--- a/test/point_test.dart
+++ b/test/point_test.dart
@@ -71,19 +71,19 @@ void main() {
           .addField('level', 2)
           .time(time);
 
-      final ns_precision =
+      final nsPrecision =
           isWeb ? '1592821563800000000' : '1592821563800123000';
       expect(point.toLineProtocol(WritePrecision.ns),
-          'h2o,location=europe level=2i $ns_precision');
+          'h2o,location=europe level=2i $nsPrecision');
 
       point = Point.measurement('h2o')
           .addTag('location', 'europe')
           .addField('level', 2)
           .time(time);
 
-      final us_precision = isWeb ? '1592821563800000' : '1592821563800123';
+      final usPrecision = isWeb ? '1592821563800000' : '1592821563800123';
       expect(point.toLineProtocol(WritePrecision.us),
-          'h2o,location=europe level=2i $us_precision');
+          'h2o,location=europe level=2i $usPrecision');
 
       point = Point.measurement('h2o')
           .addTag('location', 'europe')
@@ -108,14 +108,14 @@ void main() {
           .addField('level', 'string esc\\ape value');
 
       expect(point.toLineProtocol(WritePrecision.ns),
-          'h2o,location=europe level=\"string esc\\\\ape value\"');
+          'h2o,location=europe level="string esc\\\\ape value"');
 
       point = Point.measurement('h2o')
           .addTag('location', 'europe')
-          .addField('level', 'string esc\"ape value');
+          .addField('level', 'string esc"ape value');
 
       expect(point.toLineProtocol(WritePrecision.ns),
-          'h2o,location=europe level=\"string esc\\\"ape value\"');
+          'h2o,location=europe level="string esc\\"ape value"');
     });
   });
 }

--- a/test/point_test.dart
+++ b/test/point_test.dart
@@ -71,8 +71,7 @@ void main() {
           .addField('level', 2)
           .time(time);
 
-      final nsPrecision =
-          isWeb ? '1592821563800000000' : '1592821563800123000';
+      final nsPrecision = isWeb ? '1592821563800000000' : '1592821563800123000';
       expect(point.toLineProtocol(WritePrecision.ns),
           'h2o,location=europe level=2i $nsPrecision');
 

--- a/test/query_test.dart
+++ b/test/query_test.dart
@@ -375,4 +375,26 @@ void main() {
 
     var _ = await resp.toList();
   });
+
+  test('Accept-Encoding gzip enabled', () async {
+    client.client = MockClient((request) async {
+      expect(request.headers['Accept-Encoding'], 'gzip');
+      return Response(oneTable, 200);
+    });
+
+    var _ = await client
+        .getQueryService()
+        .query("from(bucket: 'my-bucket') |> range(start: -5s, stop: now())");
+  });
+
+  test('Accept-Encoding gzip disables', () async {
+    client.client = MockClient((request) async {
+      expect(request.headers['Accept-Encoding'], null);
+      return Response(oneTable, 200);
+    });
+
+    var _ = await client
+        .getQueryService(queryOptions: QueryOptions(gzip: false))
+        .query("from(bucket: 'my-bucket') |> range(start: -5s, stop: now())");
+  });
 }


### PR DESCRIPTION
Closes #49 

## Proposed Changes

Don't set `Accept-Encoding` header for request which doesn't use `compression`. The `Accept-Enconding` is **Forbidden header name** for web requests -  https://developer.mozilla.org/en-US/docs/Glossary/Forbidden_header_name.

## Checklist

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `pub run test` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)