### PR TITLE
fix: redact the Authorization HTTP header from log

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## 2.6.0 [unreleased]
 
+### Bug Fixes
+1. [#51](https://github.com/influxdata/influxdb-client-dart/pull/51): Redact the `Authorization` HTTP header from log
+
 ## 2.5.0 [2022-06-24]
 
 ### Bug Fixes

--- a/lib/client/influxdb_client.dart
+++ b/lib/client/influxdb_client.dart
@@ -336,7 +336,7 @@ class LoggingClient extends BaseClient {
       send.then((r) {
         logPrint(
             '<< status: ${r.statusCode} - contentLength: ${r.contentLength}');
-        logPrint('<< headers: ${r.headers}');
+        logPrint('<< headers: ${_redacted(r.headers)}');
       });
     }
     return send;
@@ -347,7 +347,14 @@ class LoggingClient extends BaseClient {
 
   void _traceRequest(BaseRequest request) {
     logPrint('>> ${request.method} ${request.url} =====');
-    logPrint('>> headers: ${request.headers}');
+    logPrint('>> headers: ${_redacted(request.headers)}');
     logPrint('>> contentLength: ${request.contentLength}');
+  }
+
+  Map<String, String> _redacted(  Map<String, String> headers) {
+    return headers.map((key, value) {
+      return MapEntry(
+          key, 'authorization' == key.toLowerCase() ? '***' : value);
+    });
   }
 }

--- a/lib/client/influxdb_client.dart
+++ b/lib/client/influxdb_client.dart
@@ -351,7 +351,7 @@ class LoggingClient extends BaseClient {
     logPrint('>> contentLength: ${request.contentLength}');
   }
 
-  Map<String, String> _redacted(  Map<String, String> headers) {
+  Map<String, String> _redacted(Map<String, String> headers) {
     return headers.map((key, value) {
       return MapEntry(
           key, 'authorization' == key.toLowerCase() ? '***' : value);

--- a/test/influxdb_client_test.dart
+++ b/test/influxdb_client_test.dart
@@ -188,13 +188,13 @@ void main() async {
 
     client.close();
   });
-  
+
   test('redacted Authorization header', () async {
     var logs = [];
     void appendLog(Object? object) {
       logs.add(object);
     }
-    
+
     client = InfluxDBClient(
         url: 'http://localhost:8086',
         org: 'my-org',

--- a/test/influxdb_client_test.dart
+++ b/test/influxdb_client_test.dart
@@ -135,7 +135,8 @@ void main() async {
         url: 'http://localhost:8086',
         org: 'my-org',
         username: 'my-username',
-        password: 'my-password');
+        password: 'my-password',
+        debug: true);
 
     var mockClient = MockClient((request) async {
       expect(request.headers['Authorization'], 'Token my-username:my-password');
@@ -186,6 +187,35 @@ void main() async {
     expect(toWrite, fromQuery);
 
     client.close();
+  });
+  
+  test('redacted Authorization header', () async {
+    var logs = [];
+    void appendLog(Object? object) {
+      logs.add(object);
+    }
+    
+    client = InfluxDBClient(
+        url: 'http://localhost:8086',
+        org: 'my-org',
+        token: 'my-token',
+        debug: true);
+    logPrint = appendLog;
+
+    var mockClient = MockClient((request) async {
+      return Response('{}', 200);
+    });
+    client.client = LoggingClient(true, mockClient);
+
+    await client.getOrganizationsApi().getOrgs();
+    client.close();
+
+    var headers = logs
+        .where((element) => element.toString().startsWith('>> headers'))
+        .first
+        .toString();
+    expect(headers, contains('Authorization: ***'));
+    logPrint = print;
   });
 }
 


### PR DESCRIPTION
## Proposed Changes

Redacted `Authorization` HTTP header from log.

## Checklist

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `pub run test` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)