### PR TITLE
chore: update linter to 2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ### Bug Fixes
 1. [#51](https://github.com/influxdata/influxdb-client-dart/pull/51): Redact the `Authorization` HTTP header from log
 
+### CI
+1. [#63](https://github.com/influxdata/influxdb-client-dart/pull/63): Update linter to `2.0.0`
+
 ## 2.5.0 [2022-06-24]
 
 ### Bug Fixes

--- a/lib/client/influxdb_client.dart
+++ b/lib/client/influxdb_client.dart
@@ -23,7 +23,7 @@ abstract class DefaultService {
     } else if (influxUrl.startsWith('http://')) {
       uri = Uri.http(influxUrl.substring('http://'.length), path, queryParams);
     } else {
-      throw ArgumentError('Invalid url: ' + influxUrl);
+      throw ArgumentError('Invalid url: $influxUrl');
     }
     return uri;
   }

--- a/lib/client/point.dart
+++ b/lib/client/point.dart
@@ -178,7 +178,7 @@ class Point {
           convertedTime = (nanos / 1000000000).round();
           break;
         default:
-          throw ArgumentError('Unsupported precision: ' + precision.toString());
+          throw ArgumentError('Unsupported precision: $precision');
       }
 
       sb.write(convertedTime);

--- a/lib/client/write_service.dart
+++ b/lib/client/write_service.dart
@@ -2,7 +2,7 @@ part of influxdb_client_api;
 
 class WriteService extends DefaultService {
   WriteOptions? writeOptions;
-  late _WriteBatch writeBatch;
+  late _WriteBatch _writeBatch;
   Timer? batchTimer;
   bool enableDebug = true;
 
@@ -12,7 +12,7 @@ class WriteService extends DefaultService {
   WriteService(InfluxDBClient client, {WriteOptions? writeOptions})
       : super(client) {
     this.writeOptions = writeOptions ?? WriteOptions();
-    writeBatch = _WriteBatch(this.writeOptions, this);
+    _writeBatch = _WriteBatch(this.writeOptions, this);
   }
 
   ///
@@ -78,21 +78,21 @@ class WriteService extends DefaultService {
     _checkNotNull('org', org);
 
     var payload = _payload(data, precision, bucket!, org!, true);
-    writeBatch.push(payload);
+    _writeBatch.push(payload);
   }
 
   ///
   /// Flushes the buffer
   ///
   Future flush() async {
-    await writeBatch.flush();
+    await _writeBatch.flush();
   }
 
   ///
   /// Flushes and Closes writeService
   ///
   Future close() async {
-    writeBatch.close;
+    _writeBatch.close;
   }
 
   ///

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -287,7 +287,7 @@ packages:
       name: lints
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.1"
+    version: "2.0.0"
   logging:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -21,4 +21,4 @@ dev_dependencies:
   mockito: any
   collection: any
   test: any
-  lints: ^1.0.1
+  lints: ">=1.0.1 <3.0.0"


### PR DESCRIPTION
## Proposed Changes

Update linter to `2.0.0`. This is fixed PR for #53.

## Checklist

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] `pub run test` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)