### PR TITLE
feat: add factory method to connect to InfluxDB 1.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,23 +92,23 @@ var client = InfluxDBClient(
 
 #### Client Options
 
-| Option | Description | Type | Default |
-|---|---|---|---|
-| url | InfluxDB url | String | none |
-| bucket | Default destination bucket for writes | String | none |
-| org | Default organization bucket for writes | String | none |
-| debug | Enable verbose logging of underlying  http client | bool | false |
+| Option | Description                                       | Type   | Default |
+|--------|---------------------------------------------------|--------|---------|
+| url    | InfluxDB url                                      | String | none    |
+| bucket | Default destination bucket for writes             | String | none    |
+| org    | Default organization bucket for writes            | String | none    |
+| debug  | Enable verbose logging of underlying  http client | bool   | false   |
 
 #### InfluxDB 1.8 API compatibility
 
 ```dart
-  var client = InfluxDBClient(
-    url: 'http://localhost:8086',
-    username: '...',
-    password: '...',
-    org: 'my-org',
-    bucket: 'my-bucket',
-    debug: true);
+var client = InfluxDBClient.connectV1(
+  url: 'http://localhost:8086',
+  database: 'mydb',
+  retentionPolicy: 'autogen',
+  username: 'my-username',
+  password: 'my-password',
+);
 ```
 
 ### Writes
@@ -340,27 +340,22 @@ void main() async {
 
 The client supports following management API:
 
-|  | API docs |
-| --- | --- |
-
-The client supports following management API:
-
-|  | API docs                                            |
-| --- |-----------------------------------------------------|
+|                                                          | API docs                                                            |
+|----------------------------------------------------------|---------------------------------------------------------------------|
 | [**AuthorizationsAPI**](lib/api/authorizations_api.dart) | https://docs.influxdata.com/influxdb/latest/api/#tag/Authorizations |
-| [**BucketsAPI**](lib/api/buckets_api.dart) | https://docs.influxdata.com/influxdb/latest/api/#tag/Buckets |
-| [**DBRPsAPI**](lib/api/DBRPs_api.dart) | https://docs.influxdata.com/influxdb/latest/api/#tag/DBRPs |
-| [**DeleteAPI**](lib/api/delete_api.dart) | https://docs.influxdata.com/influxdb/latest/api/#tag/Delete |
-| [**HealthAPI**](lib/api/health_api.dart) | https://docs.influxdata.com/influxdb/latest/api/#tag/Health |
-| [**LabelsAPI**](lib/api/labels_api.dart) | https://docs.influxdata.com/influxdb/latest/api/#tag/Labels |
-| [**OrganizationsAPI**](lib/api/organizations_api.dart) | https://docs.influxdata.com/influxdb/latest/api/#tag/Organizations |
-| [**PingAPI**](lib/api/ping_api.dart) | https://docs.influxdata.com/influxdb/latest/api/#tag/Ping |
-| [**ReadyAPI**](lib/api/ready_api.dart) | https://docs.influxdata.com/influxdb/latest/api/#tag/Ready |
-| [**SecretsAPI**](lib/api/secrets_api.dart) | https://docs.influxdata.com/influxdb/latest/api/#tag/Secrets |
-| [**SetupAPI**](lib/api/setup_api.dart) | https://docs.influxdata.com/influxdb/latest/api/#tag/Setup |
-| [**TasksAPI**](lib/api/tasks_api.dart) | https://docs.influxdata.com/influxdb/latest/api/#tag/Tasks |
-| [**UsersAPI**](lib/api/users_api.dart) | https://docs.influxdata.com/influxdb/latest/api/#tag/Users |
-| [**VariablesAPI**](lib/api/variables_api.dart) | https://docs.influxdata.com/influxdb/latest/api/#tag/Variables |
+| [**BucketsAPI**](lib/api/buckets_api.dart)               | https://docs.influxdata.com/influxdb/latest/api/#tag/Buckets        |
+| [**DBRPsAPI**](lib/api/DBRPs_api.dart)                   | https://docs.influxdata.com/influxdb/latest/api/#tag/DBRPs          |
+| [**DeleteAPI**](lib/api/delete_api.dart)                 | https://docs.influxdata.com/influxdb/latest/api/#tag/Delete         |
+| [**HealthAPI**](lib/api/health_api.dart)                 | https://docs.influxdata.com/influxdb/latest/api/#tag/Health         |
+| [**LabelsAPI**](lib/api/labels_api.dart)                 | https://docs.influxdata.com/influxdb/latest/api/#tag/Labels         |
+| [**OrganizationsAPI**](lib/api/organizations_api.dart)   | https://docs.influxdata.com/influxdb/latest/api/#tag/Organizations  |
+| [**PingAPI**](lib/api/ping_api.dart)                     | https://docs.influxdata.com/influxdb/latest/api/#tag/Ping           |
+| [**ReadyAPI**](lib/api/ready_api.dart)                   | https://docs.influxdata.com/influxdb/latest/api/#tag/Ready          |
+| [**SecretsAPI**](lib/api/secrets_api.dart)               | https://docs.influxdata.com/influxdb/latest/api/#tag/Secrets        |
+| [**SetupAPI**](lib/api/setup_api.dart)                   | https://docs.influxdata.com/influxdb/latest/api/#tag/Setup          |
+| [**TasksAPI**](lib/api/tasks_api.dart)                   | https://docs.influxdata.com/influxdb/latest/api/#tag/Tasks          |
+| [**UsersAPI**](lib/api/users_api.dart)                   | https://docs.influxdata.com/influxdb/latest/api/#tag/Users          |
+| [**VariablesAPI**](lib/api/variables_api.dart)           | https://docs.influxdata.com/influxdb/latest/api/#tag/Variables      |
 
 
 The following example demonstrates how to use a InfluxDB 2.x Management API to create new bucket. For further information see docs and [examples](example/management_api_example.dart).

--- a/lib/client/influxdb_client.dart
+++ b/lib/client/influxdb_client.dart
@@ -172,6 +172,10 @@ void Function(Object object) logPrint = print;
 /// Main InfluxDB client class
 ///
 class InfluxDBClient {
+  static const int defaultMaxRedirects = 5;
+  static const bool defaultFollowRedirects = true;
+  static const bool defaultEnableDebug = false;
+
   ///
   /// Create a new client for a InfluxDB.
   ///
@@ -184,8 +188,8 @@ class InfluxDBClient {
   ///     bucket: 'my-bucket'
   ///   );
   /// ```
-  /// * [debug] - enable/disable verbose http call traing
-  /// * [username] and [password] is only for InfluxDB 1.8 comatibility
+  /// * [debug] - enable/disable verbose http call tracing
+  /// * [username] and [password] is only for InfluxDB 1.8 compatibility
   ///
   InfluxDBClient(
       {String? url,
@@ -201,9 +205,9 @@ class InfluxDBClient {
       String? password,
 
       /// verbose logging of http calls
-      this.debug = false,
-      this.maxRedirects = 5,
-      this.followRedirects = true}) {
+      this.debug = defaultEnableDebug,
+      this.maxRedirects = defaultMaxRedirects,
+      this.followRedirects = defaultFollowRedirects}) {
     this.url = url ?? const String.fromEnvironment('INFLUXDB_URL');
     this.token = token ?? const String.fromEnvironment('INFLUXDB_TOKEN');
     this.bucket = bucket ?? const String.fromEnvironment('INFLUXDB_BUCKET');
@@ -216,14 +220,41 @@ class InfluxDBClient {
     }
     defaultHeaders['User-Agent'] = '$clientName/$clientVersion';
   }
+  ///
+  /// Create a new client for InfluxDB 1.8 compatibility API.
+  ///
+  factory InfluxDBClient.connectV1(
+      {String? url,
+      /// Username for authentication
+      String? username,
+      /// Password for authentication
+      String? password,
+      /// Target database
+      String? database,
+      /// Target retention policy
+      String? retentionPolicy,
+
+      /// verbose logging of http calls
+      bool debug = defaultEnableDebug,
+      int maxRedirects = defaultMaxRedirects,
+      bool followRedirects = defaultFollowRedirects}) {
+    return InfluxDBClient(
+        url: url,
+        bucket: '$database/$retentionPolicy',
+        username: username,
+        password: password,
+        debug: debug,
+        maxRedirects: maxRedirects,
+        followRedirects: followRedirects);
+  }
 
   String? token;
   String? url;
   String? bucket;
   String? org;
-  bool debug = false;
-  int maxRedirects = 5;
-  bool followRedirects = true;
+  bool debug = defaultEnableDebug;
+  int maxRedirects = defaultMaxRedirects;
+  bool followRedirects = defaultFollowRedirects;
 
   late Client client;
 

--- a/lib/client/influxdb_client.dart
+++ b/lib/client/influxdb_client.dart
@@ -220,17 +220,22 @@ class InfluxDBClient {
     }
     defaultHeaders['User-Agent'] = '$clientName/$clientVersion';
   }
+
   ///
   /// Create a new client for InfluxDB 1.8 compatibility API.
   ///
   factory InfluxDBClient.connectV1(
       {String? url,
+
       /// Username for authentication
       String? username,
+
       /// Password for authentication
       String? password,
+
       /// Target database
       String? database,
+
       /// Target retention policy
       String? retentionPolicy,
 

--- a/test/influxdb_client_test.dart
+++ b/test/influxdb_client_test.dart
@@ -149,6 +149,26 @@ void main() async {
     client.close();
   });
 
+  test('v1 factory', () async {
+    var client = InfluxDBClient.connectV1(
+      url: 'http://localhost:8086',
+      database: 'mydb',
+      retentionPolicy: 'autogen',
+      username: 'my-username',
+      password: 'my-password',
+    );
+
+    var mockClient = MockClient((request) async {
+      expect(request.headers['Authorization'], 'Token my-username:my-password');
+      return Response('', 200);
+    });
+    client.client = mockClient;
+
+    await client.getQueryService().query('from');
+
+    client.close();
+  });
+
   test('initialize from sys envs', () async {
     client = InfluxDBClient();
     expect(client, isNot(null));


### PR DESCRIPTION
Closes #68

## Proposed Changes

Added helper factory to connect to `1.8`:

```
var client = InfluxDBClient.connectV1(
  url: 'http://localhost:8086',
  database: 'mydb',
  retentionPolicy: 'autogen',
  username: 'my-username',
  password: 'my-password',
);
```

## Checklist

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `pub run test` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)