### PR TITLE
feat: add FluxRecord.row with response data stored in List

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## 2.7.0 [unreleased]
 
+### Features
+1. [#78](https://github.com/influxdata/influxdb-client-dart/pull/78): Added `FluxRecord.row` which stores response data in a list
+
 ## 2.6.0 [2022-07-29]
 
 ### Bug Fixes

--- a/example/README.md
+++ b/example/README.md
@@ -16,3 +16,4 @@
 - [delete_data_example.dart](delete_data_example.dart) - How to delete data from InfluxDB by client
 - [main.dart](main.dart) - How to write, query and delete data from InfluxDB
 - [invokable_scripts.dart](invokable_scripts.dart) - How to use Invokable scripts Cloud API to create custom endpoints that query data
+- [record_row_example.dart](record_row_example.dart) - How to use `FluxRecord.row`(List) instead of `FluxRecord.values`(Map), in case of duplicity column names

--- a/example/record_row_example.dart
+++ b/example/record_row_example.dart
@@ -1,0 +1,52 @@
+import 'dart:async';
+
+import 'package:influxdb_client/api.dart';
+
+void main() async {
+  var client = InfluxDBClient(
+    url: 'http://localhost:8086',
+    token: 'my-token',
+    org: 'my-org',
+    bucket: 'my-bucket',
+  );
+
+  var writeApi = client.getWriteService(WriteOptions().merge(
+      precision: WritePrecision.s,
+      batchSize: 100,
+      flushInterval: 5000,
+      gzip: true));
+
+  var point = Point('point')
+      .addField('table', 'my-table')
+      .addField('result', 3.14)
+      .time(DateTime.now().toUtc());
+
+  await writeApi.write(point);
+
+  var queryService = client.getQueryService();
+
+  var fluxQuery = '''
+  from(bucket: "my-bucket")
+  |> range(start: -1d)
+  |> filter(fn: (r) => r["_measurement"] == "point")
+  |> pivot(rowKey:["_time"], columnKey: ["_field"], valueColumn: "_value")
+  ''';
+
+  var recordStream = await queryService.query(fluxQuery);
+
+  var recordValues = [];
+  var recordRow = [];
+
+  await recordStream.forEach((record) {
+    recordValues.add(record.values.join(","));
+    recordRow.add(record.row.join(", "));
+  });
+
+  print("-------------------------- record.values ---------------------------");
+  print(recordValues.join("\n"));
+  print("---------------------------- record.row ----------------------------");
+  print(recordRow.join("\n"));
+
+  await Future.delayed(Duration(seconds: 10));
+  client.close();
+}

--- a/example/record_row_example.dart
+++ b/example/record_row_example.dart
@@ -1,5 +1,3 @@
-import 'dart:async';
-
 import 'package:influxdb_client/api.dart';
 
 void main() async {
@@ -47,6 +45,5 @@ void main() async {
   print("---------------------------- record.row ----------------------------");
   print(recordRow.join("\n"));
 
-  await Future.delayed(Duration(seconds: 10));
   client.close();
 }

--- a/lib/client/flux_table.dart
+++ b/lib/client/flux_table.dart
@@ -39,6 +39,7 @@ class FluxTableMetaData {
       }
       var csvValue = values[index];
       record[columnName] = _toValue(csvValue, column);
+      record.row.add(csvValue);
     }
 
     return record;
@@ -63,6 +64,7 @@ class FluxRecord extends MapMixin<String?, dynamic> {
   /// index of table
   final int tableIndex;
   final Map<String?, dynamic> _values = {};
+  final List<dynamic> row = [];
 
   FluxRecord(this.tableIndex);
 

--- a/lib/client/flux_transformer.dart
+++ b/lib/client/flux_transformer.dart
@@ -185,6 +185,15 @@ class FluxTransformer implements StreamTransformer<List, FluxRecord> {
       column.label = csv[i];
       i++;
     }
+
+    var duplicates = table.columns.map((item) => item.label).toList();
+    duplicates.toSet().forEach((item) => {duplicates.remove(item)});
+
+    if (duplicates.isNotEmpty) {
+      logPrint('The response contains columns with duplicated names:'
+          ' ${duplicates.join(", ")}\nYou should use the "record.row" '
+          'to access your data instead of "record.values" dictionary.');
+    }
   }
 
   void _addGroups(FluxTableMetaData table, List? csv) {

--- a/test/flux_transformer_test.dart
+++ b/test/flux_transformer_test.dart
@@ -21,5 +21,30 @@ void main() {
       expect(records[0]['value1'], 11);
       expect(records[0]['region'], 'west');
     });
+
+    test('parseDuplicateColumnNames', () async {
+      var csv =
+          '#datatype,string,long,dateTime:RFC3339,dateTime:RFC3339,dateTime:'
+          'RFC3339,string,string,double$defaultEol'
+          '#group,false,false,true,true,false,true,true,false$defaultEol'
+          '#default,_result,,,,,,,$defaultEol '
+          ',result,table,_start,_stop,_time,_measurement,location,result$defaultEol'
+          ',,0,2022-09-13T06:14:40.469404272Z,2022-09-13T06:24:40.469404272Z,'
+          '2022-09-13T06:24:33.746Z,my_measurement,Prague,25.3$defaultEol'
+          ',,0,2022-09-13T06:14:40.469404272Z,2022-09-13T06:24:40.469404272Z,'
+          '2022-09-13T06:24:39.299Z,my_measurement,Prague,25.3$defaultEol'
+          ',,0,2022-09-13T06:14:40.469404272Z,2022-09-13T06:24:40.469404272Z,'
+          '2022-09-13T06:24:40.454Z,my_measurement,Prague,25.3$defaultEol';
+
+      var records = await Stream<String>.value(csv)
+          .transform(CsvToListConverter())
+          .transform(FluxTransformer(responseMode: FluxResponseMode.onlyNames))
+          .toList();
+      print(records.join("\n"));
+      expect(records.length, 3);
+      expect(records[0].values.length, 7);
+      expect(records[0].row.length, 8);
+      expect(records[0].row[7], 25.3);
+    });
   });
 }


### PR DESCRIPTION
Closes #

## Proposed Changes

Adding possibility of accessing response data in List FluxRecord.row.

In case of using pivot on data, where field contains labels that occur by default in the annotated CSV (f.e. "result" or "table"), could be duplicated column names in response. In that case FluxRecord.values (Map), which can hold only unique keys, doesn't show complete data. This edge case is solved by using FluxRecord.row (List).

## Checklist

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `pub run test` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)