### PR TITLE
chore(ci): migrate Scheduled workflow to Scheduled pipeline

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,6 +66,9 @@ commands:
 workflows:
   version: 2
   build:
+    when:
+      not:
+        equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]
     jobs:
       - test:
           name: dart-2.12
@@ -93,13 +96,8 @@ workflows:
             - dart-2.12
 
   nightly:
-    triggers:
-      - schedule:
-          cron: "0 0 * * *"
-          filters:
-            branches:
-              only:
-                - main
+    when:
+      equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]
     jobs:
       - test:
           name: dart-latest


### PR DESCRIPTION
## Proposed Changes

The **Scheduled Workflows** uses client for nightly builds but the scheduled workflows will be phased out by the end of 2022. The CircleCI's configuration has to be migrate to **Scheduled pipelines**.

- https://circleci.com/docs/workflows/#scheduling-a-workflow
- https://circleci.com/docs/scheduled-pipelines/#migrate-scheduled-workflows

Configured trigger:

![image](https://user-images.githubusercontent.com/455137/194831055-71aa1d0a-ff2e-43c0-a56c-128953ad7289.png)


## Checklist

- [x] Rebased/mergeable
- [x] `pub run test` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)