### PR TITLE
chore(deps): change `dependabot` interval to `monthly`

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,5 +4,5 @@ updates:
   - package-ecosystem: "pub"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     open-pull-requests-limit: 10


### PR DESCRIPTION
## Proposed Changes

Changed `dependabot` interval to `monthly`. The security updates aren't affected by this change.

## Checklist

- [x] Rebased/mergeable
- [x] `pub run test` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)