### PR TITLE
chore(release): explicitly set the supported platforms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## 2.10.0 [unreleased]
 
+Explicitly set supported platforms to `android`, `ios`, `linux`, `macos`, `windows`, and `web` to avoid issues with unsupported platforms.
+
+### CI
+1. [#136](https://github.com/influxdata/influxdb-client-dart/pull/136): Fix CI pipeline for Dart 3
+
 ## 2.9.0 [2023-05-29]
 
 ### Bug Fixes

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -589,10 +589,10 @@ packages:
     dependency: transitive
     description:
       name: watcher
-      sha256: "6a7f46926b01ce81bfc339da6a7f20afbe7733eff9846f6d6a5466aa4c6667c0"
+      sha256: "3d2ad6751b3c16cf07c7fca317a1413b3f26530319181b37e3b9039b84fc01d8"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.2"
+    version: "1.1.0"
   web_socket_channel:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -22,3 +22,11 @@ dev_dependencies:
   collection: any
   test: any
   lints: ">=1.0.1 <3.0.0"
+
+platforms:
+  android:
+  ios:
+  linux:
+  macos:
+  web:
+  windows:


### PR DESCRIPTION
Closes #135

## Proposed Changes

1. Explicitly set the supported platforms in `pubspec` - add missing web
    ![image](https://github.com/influxdata/influxdb-client-dart/assets/455137/00229bec-d716-45e2-89c6-2041af96ff63)
2. Fix CI build for latest dart version: `3.x`
    ![image](https://github.com/influxdata/influxdb-client-dart/assets/455137/38756abe-ea29-4665-bbbc-5a06be5ff019)
    https://app.circleci.com/pipelines/github/influxdata/influxdb-client-dart/954/workflows/4299222c-4460-4f9d-9873-6c2541605001/jobs/4311


## Checklist

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] `pub run test` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)