### PR TITLE
Bump intl dependency to 0.19.0

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -277,10 +277,10 @@ packages:
     dependency: "direct main"
     description:
       name: intl
-      sha256: "3bc132a9dbce73a7e4a21a17d06e1878839ffbf975568bc875c60537824b0c4d"
+      sha256: d6f56758b7d3014a48af9701c085700aac781a92a87a62b1333b46d8879661cf
       url: "https://pub.dev"
     source: hosted
-    version: "0.18.1"
+    version: "0.19.0"
   io:
     dependency: transitive
     description:
@@ -618,4 +618,4 @@ packages:
     source: hosted
     version: "3.1.2"
 sdks:
-  dart: ">=2.18.0 <4.0.0"
+  dart: ">=3.0.0 <4.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
   http: ">=0.13.0 <2.0.0"
   csv: ">=4.1.0 <7.0.0"
   universal_io: ^2.0.4
-  intl: ">=0.17.0 <0.19.0"
+  intl: ^0.19.0
   meta: ^1.1.8
 
 dev_dependencies:


### PR DESCRIPTION
## Proposed Changes

To work with flutter 3.24.x we need the intl dependency to support version 0.19.0

## Checklist

- [ ] CHANGELOG.md updated
- [ ] Rebased/mergeable
- [ ] A test has been added if appropriate
- [ ] `pub run test` completes successfully
- [ ] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [ ] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)